### PR TITLE
[Feat] 로그인 페이지 마크업 및 로그인 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import SignInPage from "./features/auth/pages/SignInPage";
 import { ReservationPage } from "./features/reservations";
 
 function App() {
@@ -6,6 +7,7 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/reservation" element={<ReservationPage />} />
+        <Route path="/signin" element={<SignInPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/features/auth/api/auth.js
+++ b/src/features/auth/api/auth.js
@@ -1,0 +1,16 @@
+import supabase from "@/supabase";
+
+export const signIn = async ({ email, password }) => {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) throw error;
+  return data;
+};
+
+export const signOut = async () => {
+  const { error } = await supabase.auth.signOut();
+  if (error) throw error;
+};

--- a/src/features/auth/components/SignInForm.jsx
+++ b/src/features/auth/components/SignInForm.jsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { useSignIn } from "../hooks/useSignIn";
+
+export default function SignInForm() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const { mutate: signIn, isPending } = useSignIn();
+
+  const handleSignInSubmit = (e) => {
+    e.preventDefault();
+    signIn({ email, password });
+  };
+
+  return (
+    <form
+      onSubmit={handleSignInSubmit}
+      className="flex w-[300px] flex-col gap-4"
+    >
+      <input
+        type="email"
+        placeholder="이메일"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        className="rounded border px-3 py-2"
+      />
+      <input
+        type="password"
+        placeholder="비밀번호"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+        className="rounded border px-3 py-2"
+      />
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded bg-[#4763E4] py-2 text-white"
+      >
+        {isPending ? "로그인 중..." : "로그인"}
+      </button>
+    </form>
+  );
+}

--- a/src/features/auth/hooks/useSignIn.js
+++ b/src/features/auth/hooks/useSignIn.js
@@ -1,0 +1,17 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { signIn } from "../api/auth";
+
+export const useSignIn = () => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: signIn,
+    onSuccess: () => {
+      navigate("/reservation", { replace: true });
+    },
+    onError: (error) => {
+      alert("로그인 실패: " + error.message);
+    },
+  });
+};

--- a/src/features/auth/pages/SignInPage.jsx
+++ b/src/features/auth/pages/SignInPage.jsx
@@ -1,6 +1,9 @@
+import useRedirectIfAuthenticated from "@hooks/useRedirectIfAuthenticated";
 import SignInForm from "../components/SignInForm";
 
 export default function SignInPage() {
+  useRedirectIfAuthenticated();
+
   return (
     <main className="flex h-screen flex-col items-center justify-center gap-4 bg-gray-50">
       <h1 className="text-xl font-bold">SNAPSATHI 예약 관리 시스템</h1>

--- a/src/features/auth/pages/SignInPage.jsx
+++ b/src/features/auth/pages/SignInPage.jsx
@@ -1,0 +1,10 @@
+import SignInForm from "../components/SignInForm";
+
+export default function SignInPage() {
+  return (
+    <main className="flex h-screen flex-col items-center justify-center gap-4 bg-gray-50">
+      <h1 className="text-xl font-bold">SNAPSATHI 예약 관리 시스템</h1>
+      <SignInForm />
+    </main>
+  );
+}

--- a/src/features/reservations/pages/ReservationPage.jsx
+++ b/src/features/reservations/pages/ReservationPage.jsx
@@ -2,10 +2,13 @@ import { useState } from "react";
 import Header from "../../../components/Header";
 import Sidebar from "../../../components/Sidebar";
 import TabMenu from "../../../components/Tab/TabMenu";
+import useRedirectIfUnauthenticated from "../../../hooks/useRedirectIfUnauthenticated";
 import ReservationContent from "../components/ReservationContent";
 import { TABS } from "../constants/tabs";
 
 export default function ReservationPage() {
+  useRedirectIfUnauthenticated();
+
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   return (

--- a/src/hooks/useRedirectIfAuthenticated.js
+++ b/src/hooks/useRedirectIfAuthenticated.js
@@ -1,0 +1,21 @@
+import supabase from "@/supabase";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function useRedirectIfAuthenticated() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function checkAuth() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (session) {
+        navigate("/reservation", { replace: true });
+      }
+    }
+
+    checkAuth();
+  }, [navigate]);
+}

--- a/src/hooks/useRedirectIfUnauthenticated.js
+++ b/src/hooks/useRedirectIfUnauthenticated.js
@@ -1,0 +1,20 @@
+import supabase from "@/supabase";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function useRedirectIfUnauthenticated() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function checkAuth() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!session) {
+        navigate("/signin", { replace: true });
+      }
+    }
+    checkAuth();
+  }, [navigate]);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#17 

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 📝작업 내용 요약

- 로그인/로그아웃 요청 함수 구현
- 로그인 페이지 마크업
- 커스텀 훅(useSignIn) 구현으로 로그인 API 연동
- 로그인 상태에 따른 리다이렉션 구현

## 📸스크린샷 (선택)
<img width="956" alt="image" src="https://github.com/user-attachments/assets/a1933536-2231-4ff9-9575-6a43ef5252aa" />

## 💬리뷰 요구사항(선택)
