### PR TITLE
[Feat] 고객문의관리 페이지 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,17 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import SignInPage from "./features/auth/pages/SignInPage";
 import { ReservationPage } from "./features/reservations";
+import ReservationInquiryPage from "./features/reservations/pages/ReservationInquiryPage";
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/reservation" element={<ReservationPage />} />
+        <Route
+          path="/reservation-inquiry"
+          element={<ReservationInquiryPage />}
+        />
         <Route path="/signin" element={<SignInPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -10,7 +10,10 @@ export default function Sidebar() {
           <img src="./src/assets/logo.png"></img>
         </header>
         <nav className="flex flex-col items-start justify-center gap-6 p-5 text-white">
-          <button onClick={() => navigate("/reservation")}>예약관리</button>
+          <button onClick={() => navigate("/reservation")}>예약 목록</button>
+          <button onClick={() => navigate("/reservation-inquiry")}>
+            고객 문의
+          </button>
         </nav>
       </aside>
     </div>

--- a/src/features/reservations/api/getInquiries.js
+++ b/src/features/reservations/api/getInquiries.js
@@ -1,0 +1,19 @@
+import supabase from "@/supabase";
+
+export default async function getInquiries({ page = 1, limit = 6 }) {
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from("reservation_inquiries")
+    .select("*", { count: "exact" })
+    .eq("status", "pending")
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  const { data, error, count } = await query;
+
+  if (error) throw error;
+
+  return { data, count };
+}

--- a/src/features/reservations/components/InquiryContent.jsx
+++ b/src/features/reservations/components/InquiryContent.jsx
@@ -1,0 +1,100 @@
+import Pagination from "@components/Pagination";
+import SearchBar from "@components/SearchBar";
+import usePagination from "@hooks/usePagination";
+import useSearchFilter from "@hooks/useSearchFilter";
+import { useState } from "react";
+import InquiryList from "../components/InquiryList";
+import { PAGE_LIMIT } from "../constants/reservation";
+import useGetInquiries from "../hooks/useGetInquiries";
+
+const titleItems = {
+  id: "예약번호",
+  created_at: "생성일(한국 기준)",
+};
+
+export default function InquiryContent() {
+  const [page, setPage] = useState(1);
+
+  const {
+    data: { data: inquiryData = [], count = 0 } = {},
+    isLoading,
+    isError,
+    error,
+  } = useGetInquiries({
+    page,
+    limit: PAGE_LIMIT,
+  });
+
+  const {
+    totalPages,
+    pageNumbers,
+    groupStart,
+    groupEnd,
+    goToPrevGroup,
+    goToNextGroup,
+  } = usePagination({
+    totalCount: count,
+    pageLimit: PAGE_LIMIT,
+    currentPage: page,
+    setCurrentPage: setPage,
+  });
+
+  const {
+    searchKeyword,
+    handleSearchInputChange,
+    filteredData: filteredInquiryData,
+  } = useSearchFilter(inquiryData);
+
+  if (isError) {
+    return (
+      <div role="alert">
+        문의 목록을 불러오는 데 실패했습니다: {error.message}
+      </div>
+    );
+  }
+
+  return (
+    <section className="flex h-fit min-h-[43rem] w-full flex-col justify-between gap-4 rounded-xl bg-white px-8 py-6 text-black">
+      <div className="flex flex-col gap-5">
+        <header className="text-lg font-medium">고객 문의</header>
+        <SearchBar
+          inputValue={searchKeyword}
+          onChange={handleSearchInputChange}
+        />
+        <div className="flex flex-col">
+          <div className="flex w-full items-center gap-2 text-base font-medium text-gray-400">
+            {Object.entries(titleItems).map(([key, title]) => (
+              <div key={key} className="shrink-0 grow basis-0">
+                {title}
+              </div>
+            ))}
+          </div>
+          {isLoading ? (
+            <div className="py-8 text-center">
+              고객 문의 목록을 불러오는 중…
+            </div>
+          ) : (
+            <InquiryList inquiryData={filteredInquiryData} />
+          )}
+        </div>
+      </div>
+
+      <footer className="flex w-full items-center justify-between">
+        <div className="text-base font-normal text-[#415ac7]">
+          총 요청 {count}건
+        </div>
+        {/* //TODO: 예약 수정하고 탭 이동 시 에러 발생  */}
+        <Pagination
+          totalPages={totalPages}
+          pageNumbers={pageNumbers}
+          groupStart={groupStart}
+          groupEnd={groupEnd}
+          goToPrevGroup={goToPrevGroup}
+          goToNextGroup={goToNextGroup}
+          page={page}
+          setPage={setPage}
+        />
+      </footer>
+    </section>
+  );
+}

--- a/src/features/reservations/components/InquiryItem.jsx
+++ b/src/features/reservations/components/InquiryItem.jsx
@@ -1,0 +1,35 @@
+import { useNavigate } from "react-router-dom";
+
+export default function InquiryItem({ inquiry }) {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      onClick={() => navigate(`/reservation-inquiry/${inquiry.id}`)}
+      className="flex w-full cursor-pointer flex-col items-center hover:bg-gray-50"
+    >
+      <div className="flex flex-col items-center gap-3 self-stretch pt-3">
+        <div className="flex w-full items-center gap-2 text-sm font-normal text-gray-800">
+          {/* 예약 번호 */}
+          <div className="flex shrink-0 grow basis-0 items-center self-stretch">
+            {inquiry.reservation_number}
+          </div>
+          {/* //TODO 메시지 컬럼 추가할듯 */}
+          {/* 폼 생성 시간 */}
+          <div className="flex shrink-0 grow basis-0 items-center self-stretch">
+            {/* // TODO: 유틸 함수로 빼기 */}
+            {new Date(inquiry.created_at).toLocaleString("ko-KR", {
+              timeZone: "Asia/Seoul",
+              year: "numeric",
+              month: "2-digit",
+              day: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </div>
+        </div>
+        <div className="h-[0.0625rem] w-full bg-gray-100"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/reservations/components/InquiryList.jsx
+++ b/src/features/reservations/components/InquiryList.jsx
@@ -1,0 +1,11 @@
+import InquiryItem from "./InquiryItem";
+
+export default function InquiryList({ inquiryData }) {
+  return (
+    <>
+      {inquiryData.map((inquiry) => (
+        <InquiryItem key={inquiry.id} inquiry={inquiry} />
+      ))}
+    </>
+  );
+}

--- a/src/features/reservations/hooks/useGetInquiries.js
+++ b/src/features/reservations/hooks/useGetInquiries.js
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import getInquiries from "../api/getInquiries";
+
+export default function useGetInquiries({ page = 1, limit }) {
+  return useQuery({
+    queryKey: ["inquiries", page],
+    queryFn: () => getInquiries({ page, limit }),
+    keepPreviousData: true,
+    staleTime: 1000 * 30,
+  });
+}

--- a/src/features/reservations/pages/ReservationInquiryPage.jsx
+++ b/src/features/reservations/pages/ReservationInquiryPage.jsx
@@ -1,0 +1,25 @@
+import Header from "@components/Header";
+import Sidebar from "@components/Sidebar";
+import useRedirectIfUnauthenticated from "@hooks/useRedirectIfUnauthenticated";
+import InquiryContent from "../components/InquiryContent";
+
+export default function ReservationInquiryPage() {
+  useRedirectIfUnauthenticated();
+
+  return (
+    <div className="flex h-full flex-1 flex-row bg-gray-50">
+      <Sidebar />
+
+      <div className="flex min-h-screen w-full flex-col">
+        <Header title="고객 문의 관리" />
+        <main className="flex flex-col gap-5 px-10 py-5">
+          <h1 className="text-[2rem] font-semibold text-black">
+            고객 문의 관리
+          </h1>
+
+          <InquiryContent />
+        </main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#30 

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 📝작업 내용 요약

- 문의 목록 가져오는 api함수와 커스텀 훅 구현
- 고객 문의 목록 조회, 문의 검색 기능 추가
- 개별 문의 클릭 시 문의 상세 보기 페이지로 이동

## 📸스크린샷 (선택)
<img width="950" alt="image" src="https://github.com/user-attachments/assets/fb6f593f-555c-4674-97d9-87c3559899af" />

## 💬리뷰 요구사항(선택)
