### PR TITLE
[Feat] 고객문의상세보기 페이지 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import SignInPage from "./features/auth/pages/SignInPage";
 import { ReservationPage } from "./features/reservations";
+import ReservationInquiryDetailPage from "./features/reservations/pages/ReservationInquiryDetailPage";
 import ReservationInquiryPage from "./features/reservations/pages/ReservationInquiryPage";
 
 function App() {
@@ -11,6 +12,10 @@ function App() {
         <Route
           path="/reservation-inquiry"
           element={<ReservationInquiryPage />}
+        />
+        <Route
+          path="/reservation-inquiry/:id"
+          element={<ReservationInquiryDetailPage />}
         />
         <Route path="/signin" element={<SignInPage />} />
       </Routes>

--- a/src/features/reservations/api/getInquiryById.js
+++ b/src/features/reservations/api/getInquiryById.js
@@ -1,0 +1,12 @@
+import supabase from "@/supabase";
+
+export default async function getInquiryById(inquiryId) {
+  const { data, error } = await supabase
+    .from("reservation_inquiries")
+    .select("*")
+    .eq("id", inquiryId)
+    .eq("status", "pending")
+    .single();
+  if (error) throw error;
+  return data;
+}

--- a/src/features/reservations/api/getReservationByNumber.js
+++ b/src/features/reservations/api/getReservationByNumber.js
@@ -1,0 +1,12 @@
+import supabase from "@/supabase";
+
+export default async function getReservationByNumber(reservationNumber) {
+  const { data, error } = await supabase
+    .from("reservations")
+    .select("*")
+    .eq("reservation_number", reservationNumber)
+    .single();
+  if (error) throw error;
+
+  return data;
+}

--- a/src/features/reservations/api/updateInquiryStatus.js
+++ b/src/features/reservations/api/updateInquiryStatus.js
@@ -1,0 +1,11 @@
+import supabase from "@/supabase";
+
+export default async function updateInquiryStatus({ id, status }) {
+  console.log(id, status);
+  const { error } = await supabase
+    .from("reservation_inquiries")
+    .update({ status })
+    .eq("id", id);
+
+  if (error) throw error;
+}

--- a/src/features/reservations/hooks/useGetInquiryById.js
+++ b/src/features/reservations/hooks/useGetInquiryById.js
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import getInquiryById from "../api/getInquiryById";
+
+export default function useGetInquiryById(inquiryId) {
+  return useQuery({
+    queryKey: ["inquiry", inquiryId],
+    queryFn: () => getInquiryById(inquiryId),
+    enabled: !!inquiryId,
+    staleTime: 1000 * 30,
+  });
+}

--- a/src/features/reservations/hooks/useGetReservationByNumber.js
+++ b/src/features/reservations/hooks/useGetReservationByNumber.js
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import getReservationByNumber from "../api/getReservationByNumber";
+
+export default function useGetReservationByNumber(reservationNumber) {
+  return useQuery({
+    queryKey: ["reservation", reservationNumber],
+    queryFn: () => getReservationByNumber(reservationNumber),
+    enabled: !!reservationNumber,
+    staleTime: 1000 * 30,
+  });
+}

--- a/src/features/reservations/hooks/useUpdateInquiryStatus.js
+++ b/src/features/reservations/hooks/useUpdateInquiryStatus.js
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import updateInquiryStatus from "../api/updateInquiryStatus";
+
+export default function useUpdateInquiryStatus() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateInquiryStatus,
+    onSuccess: () => {
+      queryClient.invalidateQueries(["inquiry"]);
+    },
+  });
+}

--- a/src/features/reservations/pages/ReservationInquiryDetailPage.jsx
+++ b/src/features/reservations/pages/ReservationInquiryDetailPage.jsx
@@ -1,14 +1,17 @@
 import Button from "@components/Button";
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import ReservationForm from "../components/ReservationForm";
 import useGetInquiryById from "../hooks/useGetInquiryById";
 import useGetReservationByNumber from "../hooks/useGetReservationByNumber";
+import useUpdateInquiryStatus from "../hooks/useUpdateInquiryStatus";
 import useUpdateReservation from "../hooks/useUpdateReservation";
 
 //TODO: 리팩토링 필요
 export default function ReservationInquiryDetailPage() {
   const { id } = useParams();
+  const navigate = useNavigate();
+
   const [isEdit, setIsEdit] = useState(false);
   const [formData, setFormData] = useState({});
   const [reservationNumber, setReservationNumber] = useState(null);
@@ -37,6 +40,24 @@ export default function ReservationInquiryDetailPage() {
     closeModal: () => setIsEdit(false),
     setIsEdit,
   });
+
+  const updateInquiryStatus = useUpdateInquiryStatus();
+  const handleConfirmInquiryClick = () => {
+    if (!inquiry?.id) return;
+    if (
+      confirm("정말 문의를 종료하시겠어요?\n종료된 문의는 다시 열 수 없습니다.")
+    ) {
+      updateInquiryStatus.mutate(
+        { id: inquiry.id, status: "completed" },
+        {
+          onSuccess: () => {
+            alert("문의가 종료되었습니다.");
+            navigate("/reservation-inquiry");
+          },
+        },
+      );
+    }
+  };
 
   useEffect(() => {
     if (reservation) setFormData(reservation);
@@ -95,6 +116,13 @@ export default function ReservationInquiryDetailPage() {
         ) : (
           <>
             <Button onClick={() => setIsEdit(true)}>예약 수정하기</Button>
+            <Button
+              variant="outlined"
+              onClick={handleConfirmInquiryClick}
+              disabled={updateInquiryStatus.isLoading}
+            >
+              문의 종료하기
+            </Button>
           </>
         )}
       </div>

--- a/src/features/reservations/pages/ReservationInquiryDetailPage.jsx
+++ b/src/features/reservations/pages/ReservationInquiryDetailPage.jsx
@@ -1,0 +1,103 @@
+import Button from "@components/Button";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import ReservationForm from "../components/ReservationForm";
+import useGetInquiryById from "../hooks/useGetInquiryById";
+import useGetReservationByNumber from "../hooks/useGetReservationByNumber";
+import useUpdateReservation from "../hooks/useUpdateReservation";
+
+//TODO: 리팩토링 필요
+export default function ReservationInquiryDetailPage() {
+  const { id } = useParams();
+  const [isEdit, setIsEdit] = useState(false);
+  const [formData, setFormData] = useState({});
+  const [reservationNumber, setReservationNumber] = useState(null);
+
+  const {
+    data: inquiry,
+    isLoading: loadingRequest,
+    error: errorRequest,
+  } = useGetInquiryById(id);
+
+  useEffect(() => {
+    if (inquiry?.reservation_number) {
+      setReservationNumber(inquiry.reservation_number);
+    }
+  }, [inquiry?.reservation_number]);
+
+  const {
+    data: reservation = {},
+    isLoading: loadingReservation,
+    error: errorReservation,
+  } = useGetReservationByNumber(reservationNumber, {
+    enabled: !!reservationNumber,
+  });
+
+  const updateMutation = useUpdateReservation({
+    closeModal: () => setIsEdit(false),
+    setIsEdit,
+  });
+
+  useEffect(() => {
+    if (reservation) setFormData(reservation);
+  }, [reservation]);
+
+  const handleFormChange = (field, value) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+  const handleFormSubmit = () => {
+    const { id, created_at, ...rest } = formData;
+    const newFormData = {
+      ...rest,
+      modified_at: new Date().toISOString(),
+    };
+    updateMutation.mutate({ id, newFormData });
+  };
+
+  if (loadingReservation || loadingRequest) {
+    return <div className="p-6">로딩 중입니다...</div>;
+  }
+  if (errorReservation || errorRequest) {
+    return (
+      <div className="p-6 text-red-600">
+        오류가 발생했습니다.
+        <br />
+        {errorReservation?.message || errorRequest?.message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">예약 문의 상세</h1>
+      <div className="flex flex-col gap-4">
+        <div>
+          <h2 className="font-semibold">문의 내역</h2>
+          <p>{inquiry.message || "문의 내용이 없습니다."}</p>
+        </div>
+        <div>
+          <h2 className="font-semibold">기존 예약</h2>
+          <ReservationForm
+            reservation={formData}
+            isEdit={isEdit}
+            onChange={handleFormChange}
+          />
+        </div>
+      </div>
+      <div className="mt-8 flex gap-3">
+        {isEdit ? (
+          <>
+            <Button onClick={() => setIsEdit(false)} variant="outlined">
+              취소
+            </Button>
+            <Button onClick={handleFormSubmit}>저장</Button>
+          </>
+        ) : (
+          <>
+            <Button onClick={() => setIsEdit(true)}>예약 수정하기</Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #30

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 📝작업 내용 요약

- id에 해당하는 문의 가져오는 api함수와 커스텀 훅 구현
- 문의와 예약번호가 일치하는 예약 가져오는 api함수와 커스텀 훅 구현
- 문의 상태를 변경하는 api함수와 커스텀 훅 구현
- 고객 문의 상세보기 페이지 생성 및 
- 페이지 내에서 해당 예약을 수정 기능 추가
- 문의 종료하기 버튼 추가

## 📸스크린샷 (선택)

<img width="839" alt="image" src="https://github.com/user-attachments/assets/7491ab31-2c98-4376-9265-06f0f8336e78" />
<img width="839" alt="image" src="https://github.com/user-attachments/assets/67cdfeaa-0508-4689-b931-94840dc59b34" />

## 💬리뷰 요구사항(선택)

> 문의 상세 페이지 디자인은 추후 수정할 예정입니다.