### PR TITLE
[Feat] 로그인 유저 정보 Zustand로 관리

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,7 +1,9 @@
 import { useNavigate } from "react-router-dom";
+import useUserStore from "../stores/useUserStore";
 
 export default function Sidebar() {
   const navigate = useNavigate();
+  const { user } = useUserStore();
 
   return (
     <div>
@@ -15,6 +17,16 @@ export default function Sidebar() {
             고객 문의
           </button>
         </nav>
+
+        {/* 로그인 유저 정보 표시 */}
+        {/* //TODO 추후 위치 조정 */}
+        <div className="p-4 text-sm text-gray-300">
+          {user ? (
+            <div>👤 {user.user_metadata?.name || user.email}</div>
+          ) : (
+            <div>로그인되지 않음</div>
+          )}
+        </div>
       </aside>
     </div>
   );

--- a/src/features/auth/hooks/useSignIn.js
+++ b/src/features/auth/hooks/useSignIn.js
@@ -1,13 +1,16 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
+import useUserStore from "../../../stores/useUserStore";
 import { signIn } from "../api/auth";
 
 export const useSignIn = () => {
   const navigate = useNavigate();
+  const { setUser } = useUserStore();
 
   return useMutation({
     mutationFn: signIn,
-    onSuccess: () => {
+    onSuccess: (data) => {
+      setUser(data.user);
       navigate("/reservation", { replace: true });
     },
     onError: (error) => {

--- a/src/features/auth/hooks/useSignOut.js
+++ b/src/features/auth/hooks/useSignOut.js
@@ -1,13 +1,16 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
+import useUserStore from "../../../stores/useUserStore";
 import { signOut } from "../api/auth";
 
 export const useSignOut = () => {
   const navigate = useNavigate();
+  const { clearUser } = useUserStore();
 
   return useMutation({
     mutationFn: signOut,
     onSuccess: () => {
+      clearUser();
       navigate("/signin", { replace: true });
     },
     onError: (error) => {

--- a/src/features/reservations/api/updateInquiryStatus.js
+++ b/src/features/reservations/api/updateInquiryStatus.js
@@ -1,10 +1,15 @@
 import supabase from "@/supabase";
 
-export default async function updateInquiryStatus({ id, status }) {
+export default async function updateInquiryStatus({
+  id,
+  status,
+  reviewed_at,
+  reviewed_by,
+}) {
   console.log(id, status);
   const { error } = await supabase
     .from("reservation_inquiries")
-    .update({ status })
+    .update({ status, reviewed_at, reviewed_by })
     .eq("id", id);
 
   if (error) throw error;

--- a/src/features/reservations/components/ReservationForm.jsx
+++ b/src/features/reservations/components/ReservationForm.jsx
@@ -226,16 +226,17 @@ export default function ReservationForm({ reservation, isEdit, onChange }) {
       </div>
 
       <div className="flex flex-col gap-1">
-        {reservation.created_at && (
+        {reservation?.created_at && (
           <div className="mt-4 text-sm text-gray-500">
-            생성일: {new Date(reservation.created_at).toLocaleString()}
+            <span className="font-semibold">생성일:</span>{" "}
+            {new Date(reservation.created_at).toLocaleString()}
           </div>
         )}
-        {/* //TODO: 관리자 로그인 기능 구현 후 */}
-        {reservation.modified_at && reservation.modified_by && (
+        {reservation?.modified_at && reservation?.modified_by && (
           <div className="text-sm text-gray-500">
-            최근 수정일: {new Date(reservation.modified_at).toLocaleString()} by
-            {reservation.modified_by}
+            <span className="font-semibold">최근 수정일: </span>
+            {new Date(reservation.modified_at).toLocaleString()}{" "}
+            <span className="font-semibold">by</span> {reservation.modified_by}
           </div>
         )}
       </div>

--- a/src/features/reservations/components/ReservationModal.jsx
+++ b/src/features/reservations/components/ReservationModal.jsx
@@ -5,11 +5,13 @@ import MoreActionsDropdown from "@components/MoreActionsDropdown";
 import useDeleteReservation from "@features/reservations/hooks/useDeleteReservation";
 import useUpdateReservation from "@features/reservations/hooks/useUpdateReservation";
 import useModalStore from "@stores/useModalStore";
+import useUserStore from "@stores/useUserStore";
 import { useEffect, useState } from "react";
 import ReservationForm from "./ReservationForm";
 
 export default function ReservationModal() {
   const { isOpen, data: reservation, type, closeModal } = useModalStore();
+  const { user } = useUserStore();
 
   const [isEdit, setIsEdit] = useState(false);
   const [formData, setFormData] = useState({});
@@ -33,6 +35,7 @@ export default function ReservationModal() {
     const newFormData = {
       ...rest,
       modified_at: new Date().toISOString(),
+      modified_by: user?.email || "unknown",
     };
     updateMutation.mutate({ id, newFormData });
   };

--- a/src/stores/useUserStore.js
+++ b/src/stores/useUserStore.js
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+const useUserStore = create(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (userData) => set({ user: userData }),
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: "user-storage",
+      partialize: (state) => ({ user: state.user }),
+    },
+  ),
+);
+
+export default useUserStore;


### PR DESCRIPTION
## #️⃣연관된 이슈
#17 

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 📝작업 내용 요약

- user store 생성
- 로그인 시 유저 데이터를 Zustand 스토어에 저장하도록 수정
- 로그아웃 시 Zustand 스토어 초기화 처리
- 사이드바에 로그인 유저 정보 표시
- 예약조회/관리 UI에 수정한 관리자(유저) 이메일 표시

## 📸스크린샷 (선택)
<img width="434" alt="image" src="https://github.com/user-attachments/assets/1d206462-faeb-4a11-9f42-329502fd8e94" />

## 💬리뷰 요구사항(선택)
