### PR TITLE
[Fix]: 예약 상태가 unconfirmed → confirmed로 변경될 때만 메일 전송

### DIFF
--- a/src/features/reservations/components/ReservationModal.jsx
+++ b/src/features/reservations/components/ReservationModal.jsx
@@ -37,7 +37,7 @@ export default function ReservationModal() {
       modified_at: new Date().toISOString(),
       modified_by: user?.email || "unknown",
     };
-    updateMutation.mutate({ id, newFormData });
+    updateMutation.mutate({ id, newFormData, prevStatus: reservation.status });
   };
 
   const deleteMutation = useDeleteReservation({

--- a/src/features/reservations/hooks/useUpdateReservation.js
+++ b/src/features/reservations/hooks/useUpdateReservation.js
@@ -7,20 +7,23 @@ export default function useUpdateReservation({ closeModal, setIsEdit }) {
 
   return useMutation({
     mutationFn: ({ id, newFormData }) => updateReservation({ id, newFormData }),
-    onSuccess: async (data) => {
+    onSuccess: async (data, variables) => {
       queryClient.invalidateQueries(["reservation", data.id]);
 
-      if (data.status === "confirmed") {
+      const statusChangedToConfirmed =
+        variables.prevStatus === "unconfirmed" && data.status === "confirmed";
+
+      if (statusChangedToConfirmed) {
         try {
           await sendApprovalEmail({
             email: data.email,
             reservationNumber: data.reservation_number,
           });
 
-          alert("예약 승인 및 이메일 발송이 성공적으로 처리되었습니다.");
+          alert("예약 수정 및 이메일 발송이 성공적으로 처리되었습니다.");
         } catch (error) {
           console.log(error);
-          alert("이메일 발송에 실패했습니다.");
+          alert("이메일 발송에 실패했습니다. 다시 시도해주세요.");
         }
       } else {
         alert("예약 정보가 성공적으로 수정되었습니다.");
@@ -30,7 +33,7 @@ export default function useUpdateReservation({ closeModal, setIsEdit }) {
       closeModal();
     },
     onError: (error) => {
-      alert("요청이 실패했습니다." + error.message);
+      alert("요청이 실패했습니다. 다시 시도해주세요." + error.message);
     },
   });
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정


## 📝작업 내용 요약
- 예약 상태가 unconfirmed → confirmed로 변경될 때만 이메일을 전송하도록 함

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)
