### PR TITLE
[Feat] 문의 종료 시 고객에게 이메일 보내는 기능 추가 및 라우트 변경

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,13 +10,10 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route element={<Layout />}>
-          <Route path="/reservation" element={<ReservationPage />} />
+          <Route path="/" element={<ReservationPage />} />
+          <Route path="/inquiry" element={<ReservationInquiryPage />} />
           <Route
-            path="/reservation-inquiry"
-            element={<ReservationInquiryPage />}
-          />
-          <Route
-            path="/reservation-inquiry/:id"
+            path="inquiry/:id"
             element={<ReservationInquiryDetailPage />}
           />
         </Route>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -24,13 +24,13 @@ export default function Sidebar({ onClose }) {
           <div className="flex w-full flex-col items-start justify-start gap-3 pl-3">
             <button
               className="w-full p-1 text-start hover:bg-white/10"
-              onClick={() => handleNavigate("/reservation")}
+              onClick={() => handleNavigate("/")}
             >
               📋 예약 목록
             </button>
             <button
               className="w-full p-1 text-start hover:bg-white/10"
-              onClick={() => handleNavigate("/reservation-inquiry")}
+              onClick={() => handleNavigate("/inquiry")}
             >
               💬 고객 문의
             </button>

--- a/src/constants/page.js
+++ b/src/constants/page.js
@@ -1,4 +1,4 @@
 export const CURRENT_PAGE = {
-  reservation: "예약 목록",
-  "reservation-inquiry": "고객 문의",
+  "": "예약 목록",
+  inquiry: "고객 문의",
 };

--- a/src/features/auth/hooks/useSignIn.js
+++ b/src/features/auth/hooks/useSignIn.js
@@ -11,7 +11,7 @@ export const useSignIn = () => {
     mutationFn: signIn,
     onSuccess: (data) => {
       setUser(data.user);
-      navigate("/reservation", { replace: true });
+      navigate("/", { replace: true });
     },
     onError: (error) => {
       alert("로그인 실패: " + error.message);

--- a/src/features/reservations/api/sendInquiryCompleteEmail.js
+++ b/src/features/reservations/api/sendInquiryCompleteEmail.js
@@ -1,0 +1,23 @@
+const FUNCTION_URL = import.meta.env.VITE_SUPABASE_FUNCTION_URL;
+const ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export default async function sendInquiryCompleteEmail({
+  email,
+  reservationNumber,
+}) {
+  const res = await fetch(`${FUNCTION_URL}/send-inquiry-complete-email`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${ANON_KEY}`,
+    },
+    body: JSON.stringify({ email, reservationNumber }),
+  });
+
+  if (!res.ok) {
+    const errorBody = await res.text();
+    throw new Error(`이메일 전송 실패: ${errorBody}`);
+  }
+
+  return res.json();
+}

--- a/src/features/reservations/components/InquiryDetailContent.jsx
+++ b/src/features/reservations/components/InquiryDetailContent.jsx
@@ -34,24 +34,19 @@ export default function InquiryDetailContent({
 
   const updateInquiryStatus = useUpdateInquiryStatus();
   const handleConfirmInquiryClick = () => {
-    if (!inquiry?.id) return;
+    if (!inquiry?.id || !reservation.email || !reservationNumber) {
+      return;
+    }
     if (
       confirm("정말 문의를 종료하시겠어요?\n종료된 문의는 다시 열 수 없습니다.")
     ) {
-      updateInquiryStatus.mutate(
-        {
-          id: inquiry.id,
-          reviewed_at: new Date().toISOString(),
-          reviewed_by: user?.email || "unknown",
-          status: "completed",
-        },
-        {
-          onSuccess: () => {
-            alert("문의가 종료되었습니다.");
-            navigate("/inquiry");
-          },
-        },
-      );
+      updateInquiryStatus.mutate({
+        id: inquiry.id,
+        email: reservation.email,
+        reservationNumber: reservationNumber,
+        reviewed_at: new Date().toISOString(),
+        reviewed_by: user?.email || "unknown",
+      });
     }
   };
 

--- a/src/features/reservations/components/InquiryDetailContent.jsx
+++ b/src/features/reservations/components/InquiryDetailContent.jsx
@@ -48,7 +48,7 @@ export default function InquiryDetailContent({
         {
           onSuccess: () => {
             alert("문의가 종료되었습니다.");
-            navigate("/reservation-inquiry");
+            navigate("/inquiry");
           },
         },
       );

--- a/src/features/reservations/components/InquiryItem.jsx
+++ b/src/features/reservations/components/InquiryItem.jsx
@@ -6,7 +6,7 @@ export default function InquiryItem({ inquiry }) {
   const navigate = useNavigate();
   return (
     <div
-      onClick={() => navigate(`/reservation-inquiry/${inquiry.id}`)}
+      onClick={() => navigate(`/inquiry/${inquiry.id}`)}
       className="flex w-full cursor-pointer flex-col items-center hover:bg-gray-50"
     >
       <div className="flex flex-col items-center gap-3 self-stretch pt-3">

--- a/src/features/reservations/hooks/useGetInquiryById.js
+++ b/src/features/reservations/hooks/useGetInquiryById.js
@@ -1,11 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import getInquiryById from "../api/getInquiryById";
 
-export default function useGetInquiryById(inquiryId) {
+export default function useGetInquiryById(inquiryId, options = {}) {
   return useQuery({
     queryKey: ["inquiry", inquiryId],
     queryFn: () => getInquiryById(inquiryId),
-    enabled: !!inquiryId,
+    enabled: !!inquiryId && options.enabled !== false,
     staleTime: 1000 * 30,
   });
 }

--- a/src/features/reservations/hooks/useUpdateInquiryStatus.js
+++ b/src/features/reservations/hooks/useUpdateInquiryStatus.js
@@ -1,13 +1,45 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import sendInquiryCompleteEmail from "../api/sendInquiryCompleteEmail";
 import updateInquiryStatus from "../api/updateInquiryStatus";
 
 export default function useUpdateInquiryStatus() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   return useMutation({
-    mutationFn: updateInquiryStatus,
+    mutationFn: async ({
+      id,
+      email,
+      reservationNumber,
+      reviewed_at,
+      reviewed_by,
+    }) => {
+      try {
+        await sendInquiryCompleteEmail({ email, reservationNumber });
+      } catch (err) {
+        console.error(err);
+        throw new Error("이메일 발송에 실패했습니다.");
+      }
+
+      // 이메일 성공 시에만 상태를 'completed'로 업데이트
+      return await updateInquiryStatus({
+        id,
+        status: "completed",
+        reviewed_at,
+        reviewed_by,
+      });
+    },
     onSuccess: () => {
       queryClient.invalidateQueries(["inquiry"]);
+      alert("문의가 종료되었습니다.");
+      navigate("/inquiry");
+    },
+
+    onError: (error) => {
+      alert(
+        `문의 종료 중 오류가 발생했습니다. 다시 시도해주세요.\n\n에러 메시지: ${error.message}`,
+      );
     },
   });
 }

--- a/src/features/reservations/pages/ReservationInquiryDetailPage.jsx
+++ b/src/features/reservations/pages/ReservationInquiryDetailPage.jsx
@@ -1,24 +1,28 @@
+import useRedirectIfUnauthenticated from "@hooks/useRedirectIfUnauthenticated";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import InquiryDetailContent from "../components/InquiryDetailContent";
 import useGetInquiryById from "../hooks/useGetInquiryById";
 
 export default function ReservationInquiryDetailPage() {
-  const { id } = useParams();
-
+  const { isAuthenticated } = useRedirectIfUnauthenticated();
   const [reservationNumber, setReservationNumber] = useState(null);
+
+  const { id } = useParams();
 
   const {
     data: inquiry,
     isLoading: loadingRequest,
     error: errorRequest,
-  } = useGetInquiryById(id);
+  } = useGetInquiryById(id, { enabled: isAuthenticated });
 
   useEffect(() => {
     if (inquiry?.reservation_number) {
       setReservationNumber(inquiry.reservation_number);
     }
   }, [inquiry?.reservation_number]);
+
+  if (!isAuthenticated) return null;
 
   return (
     <main className="flex flex-col gap-5 px-5 py-5 md:px-10">

--- a/src/features/reservations/pages/ReservationInquiryPage.jsx
+++ b/src/features/reservations/pages/ReservationInquiryPage.jsx
@@ -2,7 +2,9 @@ import useRedirectIfUnauthenticated from "@hooks/useRedirectIfUnauthenticated";
 import InquiryContent from "../components/InquiryContent";
 
 export default function ReservationInquiryPage() {
-  useRedirectIfUnauthenticated();
+  const { isAuthenticated } = useRedirectIfUnauthenticated();
+
+  if (!isAuthenticated) return null;
 
   return (
     <main className="flex flex-col gap-5 px-5 py-5 md:px-10">

--- a/src/features/reservations/pages/ReservationPage.jsx
+++ b/src/features/reservations/pages/ReservationPage.jsx
@@ -1,13 +1,14 @@
+import TabMenu from "@components/Tab/TabMenu";
+import useRedirectIfUnauthenticated from "@hooks/useRedirectIfUnauthenticated";
 import { useState } from "react";
-import TabMenu from "../../../components/Tab/TabMenu";
-import useRedirectIfUnauthenticated from "../../../hooks/useRedirectIfUnauthenticated";
 import ReservationContent from "../components/ReservationContent";
 import { TABS } from "../constants/reservation";
 
 export default function ReservationPage() {
-  useRedirectIfUnauthenticated();
-
+  const { isAuthenticated } = useRedirectIfUnauthenticated();
   const [selectedIndex, setSelectedIndex] = useState(0);
+
+  if (!isAuthenticated) return null;
 
   return (
     <main className="flex flex-col gap-5 px-5 py-5 md:px-10">

--- a/src/hooks/useRedirectIfAuthenticated.js
+++ b/src/hooks/useRedirectIfAuthenticated.js
@@ -12,7 +12,7 @@ export default function useRedirectIfAuthenticated() {
       } = await supabase.auth.getSession();
 
       if (session) {
-        navigate("/reservation", { replace: true });
+        navigate("/", { replace: true });
       }
     }
 

--- a/src/hooks/useRedirectIfUnauthenticated.js
+++ b/src/hooks/useRedirectIfUnauthenticated.js
@@ -1,9 +1,10 @@
 import supabase from "@/supabase";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 export default function useRedirectIfUnauthenticated() {
   const navigate = useNavigate();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   useEffect(() => {
     async function checkAuth() {
@@ -13,8 +14,12 @@ export default function useRedirectIfUnauthenticated() {
 
       if (!session) {
         navigate("/signin", { replace: true });
+      } else {
+        setIsAuthenticated(true);
       }
     }
     checkAuth();
   }, [navigate]);
+
+  return { isAuthenticated };
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정

## 📝작업 내용 요약
- 문의 완료 시 고객에게 이메일 발송하는 기능 추가
- 라우트 경로 간단하게 변경( `/reservation`-> `/` , `/reservation-inquiry` -> `/inquiry` )
- 인증 상태 확인 전 페이지 잠깐 보이는 이슈 해결

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)
